### PR TITLE
chore(build): switch on `strictPropertyInitialization` flag

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"skipLibCheck": true,
+		"strictPropertyInitialization": true,
 		"noImplicitReturns": true,
 		"noImplicitAny": true,
 		"strictNullChecks": true,


### PR DESCRIPTION
`--strictPropertyInitialization` which errors on properties which are not directly initialized on their declarations or in constructor bodies. While easy to opt out of by explicitly turning this check off, your code may be impacted.