### PR TITLE
chore: update lerna to v3.2.1 and fix lerna/cli breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,18 @@ These are:
 
 ## NPM Tasks
 
-| Task       | Description                                                                                     |
-|------------|-------------------------------------------------------------------------------------------------|
-| aio        | Generates a static documentation of your libraries                                              |
-| bootstrap  | Install packages dependencies and bootstrap the mono repo                                       |
-| build      | Build all the packages inside the mono repo                                                     |
-| watch      | Build all the packages inside the mono repo and perform an incremental build when a file changes (NB: in case you have cross dependencies it's recommanded that you first perform a build)|
-| build-tools| Build the tools script that are used for building the mono repo                                 |
-| clean      | Clean up packages `node_modules` and `dist` folders                                             |
-| test       | Run unit and integration tests                                                                  |
-| test-debug | Run unit and integration tests in debug mode                                                    |
-| test-tdd   | Run unit and integration tests in watch mode                                                    |
+| Task         | Description                                                                                                                                                                                |
+| ------------ | -------------------------------------------------------------------------------------------------                                                                                          |
+| aio          | Generates a static documentation of your libraries                                                                                                                                         |
+| bootstrap    | Install packages dependencies and bootstrap the mono repo                                                                                                                                  |
+| build        | Build all the packages inside the mono repo                                                                                                                                                |
+| watch        | Build all the packages inside the mono repo and perform an incremental build when a file changes (NB: in case you have cross dependencies it's recommanded that you first perform a build) |
+| build-tools  | Build the tools script that are used for building the mono repo                                                                                                                            |
+| clean        | Clean up packages `node_modules` and `dist` folders                                                                                                                                        |
+| test         | Run unit and integration tests                                                                                                                                                             |
+| test-debug   | Run unit and integration tests in debug mode                                                                                                                                               |
+| test-tdd     | Run unit and integration tests in watch mode                                                                                                                                               |
+| release      | Runs `lerna publish $@`, but with the underlying `npm publish` calls patched to use the `dist` subdirectory. E.g. `npm run release premajor --preid alpha --npm-tag alpha`                     |
 
 ## Testing
 For this project, I chose Jest as our test framework. While Karma is probably more common for Angular testing, Karma is slower and doesn't offer some important features that Jest does.

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,14 +518,14 @@
 			}
 		},
 		"@lerna/add": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.1.1.tgz",
-			"integrity": "sha512-hL00O/0Jv8j1k+/A7gVBA/eBzB7cdwTMGeNGh/lEbqGKKIf1yflW7yr+kM1q2JeoZM8cUP5xQSygJ6Grlu2qqw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.2.0.tgz",
+			"integrity": "sha512-qGA7agAWcKlrXZR3FwFJXTr26Q2rqjOVMNhtm8uyawImqfdKp4WJXuGdioiWOSW20jMvzLIFhWZh5lCh0UyMBw==",
 			"dev": true,
 			"requires": {
-				"@lerna/bootstrap": "^3.1.0",
-				"@lerna/command": "^3.1.0",
-				"@lerna/filter-options": "^3.0.5",
+				"@lerna/bootstrap": "^3.2.0",
+				"@lerna/command": "^3.1.3",
+				"@lerna/filter-options": "^3.1.2",
 				"@lerna/npm-conf": "^3.0.0",
 				"@lerna/validation-error": "^3.0.0",
 				"dedent": "^0.7.0",
@@ -536,33 +536,33 @@
 			}
 		},
 		"@lerna/batch-packages": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.0.0.tgz",
-			"integrity": "sha512-0tN9oNykfIhdFaxEEHxF1S8K7wJdRjzGmbMhrirNogk7I2sLP82aoKH4rLCAdwidX5OvDhzlyQM0MC86T7Lazg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.1.2.tgz",
+			"integrity": "sha512-HAkpptrYeUVlBYbLScXgeCgk6BsNVXxDd53HVWgzzTWpXV4MHpbpeKrByyt7viXlNhW0w73jJbipb/QlFsHIhQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/package-graph": "^3.0.0",
+				"@lerna/package-graph": "^3.1.2",
 				"@lerna/validation-error": "^3.0.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/bootstrap": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.1.0.tgz",
-			"integrity": "sha512-zpv+XEYzuwJkKKKD+PLqubJkvsYFU1sD776pmIMUm4ryyQaNXMuZEc0Vawzmdm2rf4LMcCoAlzQcOe4ru9JX8w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.2.0.tgz",
+			"integrity": "sha512-xh6dPpdzsAEWF7lqASaym5AThkmP3ArR7Q+P/tiPWCT+OT7QT5QI2IQAz1aAYEBQL3ACzpE6kq+VOGi0m+9bxw==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0",
-				"@lerna/command": "^3.1.0",
-				"@lerna/filter-options": "^3.0.5",
+				"@lerna/batch-packages": "^3.1.2",
+				"@lerna/command": "^3.1.3",
+				"@lerna/filter-options": "^3.1.2",
 				"@lerna/has-npm-version": "^3.0.4",
 				"@lerna/npm-conf": "^3.0.0",
 				"@lerna/npm-install": "^3.0.0",
 				"@lerna/rimraf-dir": "^3.0.0",
-				"@lerna/run-lifecycle": "^3.0.0",
+				"@lerna/run-lifecycle": "^3.2.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
-				"@lerna/symlink-binary": "^3.0.0",
-				"@lerna/symlink-dependencies": "^3.0.0",
+				"@lerna/symlink-binary": "^3.1.4",
+				"@lerna/symlink-dependencies": "^3.1.4",
 				"@lerna/validation-error": "^3.0.0",
 				"dedent": "^0.7.0",
 				"get-port": "^3.2.0",
@@ -578,16 +578,16 @@
 			}
 		},
 		"@lerna/changed": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.1.0.tgz",
-			"integrity": "sha512-VfyGns+ASBE+AwoRzsRCqDeWmjElZotUVPAyVAFBdeoyoSv2EHIx+LTcdFtQVZp6VSnreU0bPeJ8ZZQ/DNdjug==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.2.0.tgz",
+			"integrity": "sha512-R+vGzzXPN5s5lJT0v1zSTLw43O2ek2yekqCqvw7p9UFqgqYSbxUsyWXMdhku/mOIFWTc6DzrsOi+U7CX3TXmHg==",
 			"dev": true,
 			"requires": {
 				"@lerna/collect-updates": "^3.1.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"@lerna/listable": "^3.0.0",
 				"@lerna/output": "^3.0.0",
-				"@lerna/version": "^3.1.0"
+				"@lerna/version": "^3.2.0"
 			}
 		},
 		"@lerna/check-working-tree": {
@@ -642,13 +642,13 @@
 			}
 		},
 		"@lerna/clean": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.1.0.tgz",
-			"integrity": "sha512-qTtSE3Uce0VHMFyUy81Ia+bmHHjWGM6GDaJZ7MdpZhlu1tJDw6rdmXsfV9ezDGn2M31neUj1kW2On7Oge/n2iw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.1.3.tgz",
+			"integrity": "sha512-XVdcIOjhudXlk5pTXjrpsnNLqeVi2rBu2oWzPH2GHrxWGBZBW8thGIFhQf09da/RbRT3uzBWXpUv+sbL2vbX3g==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "^3.1.0",
-				"@lerna/filter-options": "^3.0.5",
+				"@lerna/command": "^3.1.3",
+				"@lerna/filter-options": "^3.1.2",
 				"@lerna/prompt": "^3.0.0",
 				"@lerna/rimraf-dir": "^3.0.0",
 				"p-map": "^1.2.0",
@@ -657,28 +657,13 @@
 			}
 		},
 		"@lerna/cli": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.1.1.tgz",
-			"integrity": "sha512-v5oGELL2/Pf4//Af6o1AFOnXUKplyslTCvq0LviQKc2B4dGmix0euSYrvAG8eJlnh8quBVsCS96lioMrYL/bxg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.2.0.tgz",
+			"integrity": "sha512-JdbLyTxHqxUlrkI+Ke+ltXbtyA+MPu9zR6kg/n8Fl6uaez/2fZWtReXzYi8MgLxfUFa7+1OHWJv4eAMZlByJ+Q==",
 			"dev": true,
 			"requires": {
-				"@lerna/add": "^3.1.1",
-				"@lerna/bootstrap": "^3.1.0",
-				"@lerna/changed": "^3.1.0",
-				"@lerna/clean": "^3.1.0",
-				"@lerna/create": "^3.1.0",
-				"@lerna/diff": "^3.1.0",
-				"@lerna/exec": "^3.1.0",
-				"@lerna/global-options": "^3.0.5",
-				"@lerna/import": "^3.1.0",
-				"@lerna/init": "^3.1.0",
-				"@lerna/link": "^3.1.0",
-				"@lerna/list": "^3.1.0",
-				"@lerna/publish": "^3.1.0",
-				"@lerna/run": "^3.1.0",
-				"@lerna/version": "^3.1.0",
+				"@lerna/global-options": "^3.1.3",
 				"dedent": "^0.7.0",
-				"is-ci": "^1.0.10",
 				"npmlog": "^4.1.2",
 				"yargs": "^12.0.1"
 			},
@@ -797,20 +782,19 @@
 			}
 		},
 		"@lerna/command": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.1.0.tgz",
-			"integrity": "sha512-KSt7HMtVr6tmTugQiJ0kqN8qK5QR9ttSMM/iXc1sERrAna4/NeSJkdu0lILaInAoNrygteY3xqrL/z/2Rbemow==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.1.3.tgz",
+			"integrity": "sha512-ptaFNsfcTpxnSkaNrGgW3fRbWWVSVDUx4BpkjUUnRTgy9mwoykQWgQB3inhgTYHwW6e4PzO79F2hovfUMzHuzg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.0.0",
-				"@lerna/collect-updates": "^3.1.0",
-				"@lerna/filter-packages": "^3.0.0",
-				"@lerna/package-graph": "^3.0.0",
+				"@lerna/package-graph": "^3.1.2",
 				"@lerna/project": "^3.0.0",
 				"@lerna/validation-error": "^3.0.0",
 				"@lerna/write-log-file": "^3.0.0",
 				"dedent": "^0.7.0",
 				"execa": "^0.10.0",
+				"is-ci": "^1.0.10",
 				"lodash": "^4.17.5",
 				"npmlog": "^4.1.2"
 			},
@@ -877,13 +861,13 @@
 			}
 		},
 		"@lerna/create": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.1.0.tgz",
-			"integrity": "sha512-Jnoz2Wvs69rSxiptRDSCAwcL0Ip8YC2TJcDDk3Jc4G3yRnLWFiNGGUdDSwoSYNacpZICzenb4nzq72dDWV/9nw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.1.3.tgz",
+			"integrity": "sha512-CmXKCBc6AE3F9O6mMg4Y76cQ8eTCy3ksqDFKxVQMdYDtHKnTrH1s0l8sn3J1AiylqVDnvxhb3Rjyj+OWyzmFPQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.0.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"@lerna/npm-conf": "^3.0.0",
 				"@lerna/validation-error": "^3.0.0",
 				"camelcase": "^4.1.0",
@@ -975,37 +959,39 @@
 			}
 		},
 		"@lerna/diff": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.1.0.tgz",
-			"integrity": "sha512-7w4FWDuoERaW5UoBAR9iD1ITGCkAH4RWjkaLoiMTl1MnMuUksBNWFHFfThnfQPfBBxNSogskw5EJMg3IxlqfZg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.1.3.tgz",
+			"integrity": "sha512-30G74DxdQC4dR3U0yqh5mjcioLDUmSy1ntntdF3khvKV9oiMVzCSOO0oOlSwIdmohke+bQ//oF+oyl0Dy1TUTQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.0.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"@lerna/validation-error": "^3.0.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/exec": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.1.0.tgz",
-			"integrity": "sha512-Y7RxJigf3xPl3dgdmDQRYaDAKuR0YqEnxB/SAu3r/40hm+TVqHXqXqxWcY0FOcovTVoPz6B57IqoZ7peUGX9Gw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.1.3.tgz",
+			"integrity": "sha512-r0yQj9Rza5a42Shts8rXYGU1/Va8hO2atk/TEZgrA1EcTwgZyAuXsuML5UWbC/eLgwEjVDmc3MUSj8O1JijBMQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0",
+				"@lerna/batch-packages": "^3.1.2",
 				"@lerna/child-process": "^3.0.0",
-				"@lerna/command": "^3.1.0",
-				"@lerna/filter-options": "^3.0.5",
+				"@lerna/command": "^3.1.3",
+				"@lerna/filter-options": "^3.1.2",
 				"@lerna/run-parallel-batches": "^3.0.0",
 				"@lerna/validation-error": "^3.0.0"
 			}
 		},
 		"@lerna/filter-options": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.0.5.tgz",
-			"integrity": "sha512-yQZrzIDRE3ze62iESMNgbU5eBNb6LPZLJOX0n0MHgpR/7pSLbvJMt8i54GLxm1grCa5O+vgP2DNjcKU17c5eTQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.1.2.tgz",
+			"integrity": "sha512-smbvSGK/eU+7PDKO4jbJ7XYO2XTfhnwPeOTuwSm1mlWS5dUGasYkhAuFzouFh60aZBvmW0e6APe0XYeofQNcCg==",
 			"dev": true,
 			"requires": {
+				"@lerna/collect-updates": "^3.1.0",
+				"@lerna/filter-packages": "^3.0.0",
 				"dedent": "^0.7.0"
 			}
 		},
@@ -1030,9 +1016,9 @@
 			}
 		},
 		"@lerna/global-options": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.0.5.tgz",
-			"integrity": "sha512-GC4JFYT9rTZO0k1nBJ0X1pgOFAtu6xxWQ8XMRbboX6uHFn5h6pvS7X7uMLaWRF4k2izVxnCq3Bx8FXNZlmY3Tg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.1.3.tgz",
+			"integrity": "sha512-LVeZU/Zgc0XkHdGMRYn+EmHfDmmYNwYRv3ta59iCVFXLVp7FRFWF7oB1ss/WRa9x/pYU0o6L8as/5DomLUGASA==",
 			"dev": true
 		},
 		"@lerna/has-npm-version": {
@@ -1046,13 +1032,13 @@
 			}
 		},
 		"@lerna/import": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.1.0.tgz",
-			"integrity": "sha512-ytLUe81m3ACGDx/VCX2GphUbub9STZGWui/uyGMxMGvh4Ht728onP8RiU8Ov85jy7fKicZJbd/jUHuvnYJMH6g==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.1.3.tgz",
+			"integrity": "sha512-+XV/EHXEHbyMmprz8zQa0VF0TZ+txRIrcF3Q/PsuZ4isVxawIbP1CmgE0yn0/1XSNJwGKsuPfGauRtnjUi2LJw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.0.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"@lerna/prompt": "^3.0.0",
 				"@lerna/validation-error": "^3.0.0",
 				"dedent": "^0.7.0",
@@ -1074,13 +1060,13 @@
 			}
 		},
 		"@lerna/init": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.1.0.tgz",
-			"integrity": "sha512-x+8na2vdTsg0Z1IYHrUn5mlUpgvgPPyq/elK7s47zkCSEQJ6hN/eTs8a5rVUBFlXOFXDoEA1ceXY3gju1rdCww==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.1.3.tgz",
+			"integrity": "sha512-c418p6fAfJ+b/tidB8/O/ABGLX7a5y5uJSWxH2/Mp7i5da/RD27XJ6E6818hGAbUbVQw04+XuXHtrWYlWLEJCw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.0.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"fs-extra": "^6.0.1",
 				"p-map": "^1.2.0",
 				"write-json-file": "^2.3.0"
@@ -1100,26 +1086,26 @@
 			}
 		},
 		"@lerna/link": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.1.0.tgz",
-			"integrity": "sha512-KT5hXF1UWIcFt5Mbr+bBh/3o8fIpYnurvb2r1C04xKdDqz9tav+9vggaFa0t6KEv8QhIKZXwqLH9YDqfpkpBZw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.1.4.tgz",
+			"integrity": "sha512-AAl4ctKtE6975zxdrsr16CAh/K4y0ZjjY9XDdD+zMxsSPELvRVG6M36O1A72AmKz5Nhh1l82bPrw7w54TbQ8hA==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "^3.1.0",
-				"@lerna/package-graph": "^3.0.0",
-				"@lerna/symlink-dependencies": "^3.0.0",
+				"@lerna/command": "^3.1.3",
+				"@lerna/package-graph": "^3.1.2",
+				"@lerna/symlink-dependencies": "^3.1.4",
 				"p-map": "^1.2.0",
 				"slash": "^1.0.0"
 			}
 		},
 		"@lerna/list": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.1.0.tgz",
-			"integrity": "sha512-J1f8vL4fQhALazyb3MS0Yw3OVMS9F3F4z8XqjlDPlyMdlNSRR5UBkcxxXRcz8A5nxMt3VYoBnX6AfHw19db2sw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.1.3.tgz",
+			"integrity": "sha512-/ncX5Kj1ddLgZuBkjaoluJgcmAAm/L4/AymVNBgVrw6dOad0C0RB6oIcRAbxDennEQ25wSOFmuXRZHYHY9VYyg==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "^3.1.0",
-				"@lerna/filter-options": "^3.0.5",
+				"@lerna/command": "^3.1.3",
+				"@lerna/filter-options": "^3.1.2",
 				"@lerna/listable": "^3.0.0",
 				"@lerna/output": "^3.0.0"
 			}
@@ -1204,9 +1190,9 @@
 			}
 		},
 		"@lerna/npm-publish": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.0.6.tgz",
-			"integrity": "sha512-PlvKr958TowEOOe2yNtmUi/Ot42TS/edlmA7rj+XtDUR51AN3RB9G6b25TElyrnDksj1ayb3mOF7I2uf1gbyOw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.2.0.tgz",
+			"integrity": "sha512-x13EGrjZk9w8gCQAE44aKbeO1xhLizLJ4tKjzZmQqKEaUCugF4UU8ZRGshPMRFBdsHTEWh05dkKx2oPMoaf0dw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.0.0",
@@ -1262,11 +1248,12 @@
 			}
 		},
 		"@lerna/package-graph": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.0.0.tgz",
-			"integrity": "sha512-kD9ezB7UT2I0BbVv3+ZYfR/t/Z+z6RJmaI/OkvEaZ3bAcAqQRV4zTDdh2Xeiead+UwsA38xf7Z6pDEMWzswLVg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.1.2.tgz",
+			"integrity": "sha512-9wIWb49I1IJmyjPdEVZQ13IAi9biGfH/OZHOC04U2zXGA0GLiY+B3CAx6FQvqkZ8xEGfqzmXnv3LvZ0bQfc1aQ==",
 			"dev": true,
 			"requires": {
+				"@lerna/validation-error": "^3.0.0",
 				"npm-package-arg": "^6.0.0",
 				"semver": "^5.5.0"
 			}
@@ -1368,31 +1355,32 @@
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.1.0.tgz",
-			"integrity": "sha512-IC2g8wrjkTsqCNG+j+s7Q+2yOw3ZGhn+n1RwgG3cSUOGDBy39EB5v+JY/gB8I8llffPjpQGzjDCQ5Iax2fuuUA==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.2.1.tgz",
+			"integrity": "sha512-SnSBstK/G9qLt5rS56pihNacgsu3UgxXiCexWb57GGEp2eDguQ7rFzxVs4JMQQWmVG97EMJQxfFV54tW2sqtIw==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0",
+				"@lerna/batch-packages": "^3.1.2",
 				"@lerna/check-working-tree": "^3.1.0",
 				"@lerna/child-process": "^3.0.0",
 				"@lerna/collect-updates": "^3.1.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"@lerna/describe-ref": "^3.1.0",
 				"@lerna/get-npm-exec-opts": "^3.0.0",
 				"@lerna/npm-dist-tag": "^3.0.0",
-				"@lerna/npm-publish": "^3.0.6",
+				"@lerna/npm-publish": "^3.2.0",
 				"@lerna/output": "^3.0.0",
 				"@lerna/prompt": "^3.0.0",
-				"@lerna/run-lifecycle": "^3.0.0",
+				"@lerna/run-lifecycle": "^3.2.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
 				"@lerna/validation-error": "^3.0.0",
-				"@lerna/version": "^3.1.0",
+				"@lerna/version": "^3.2.0",
 				"fs-extra": "^6.0.1",
 				"npm-package-arg": "^6.0.0",
 				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
+				"p-pipe": "^1.2.0",
 				"p-reduce": "^1.0.0",
 				"semver": "^5.5.0"
 			},
@@ -1447,14 +1435,14 @@
 			}
 		},
 		"@lerna/run": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.1.0.tgz",
-			"integrity": "sha512-yrAvM9ZTN0cUahTpih0c937lp8Iml8YXRRbhZscPQ33pNTppgCi5iTLqnp4srN1hCk3ljyN4nYX2a1STm1GGnw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.1.3.tgz",
+			"integrity": "sha512-O26WdR+sQFSG2Fpc67nw+m8oVq3R+H6jsscKuB6VJafU+V4/hPURSbuFZIcmnD9MLmzAIhlQiCf0Fy6s/1MPPA==",
 			"dev": true,
 			"requires": {
-				"@lerna/batch-packages": "^3.0.0",
-				"@lerna/command": "^3.1.0",
-				"@lerna/filter-options": "^3.0.5",
+				"@lerna/batch-packages": "^3.1.2",
+				"@lerna/command": "^3.1.3",
+				"@lerna/filter-options": "^3.1.2",
 				"@lerna/npm-run-script": "^3.0.0",
 				"@lerna/output": "^3.0.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
@@ -1463,9 +1451,9 @@
 			}
 		},
 		"@lerna/run-lifecycle": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.0.0.tgz",
-			"integrity": "sha512-kfq6eC5mCreTk7GusZyvF0/BfU9FDEt8JaUgzNKLrK1Sj6z2RO8uSpFsUlj+7OuV4wo0I+rdTdJOAFoW8C0GZw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.2.0.tgz",
+			"integrity": "sha512-kGGdHJRyeZF+VTtal1DBptg6qwIsOLg3pKtmRm1rCMNN7j4kgrA9L07ZoRar8LjQXvfuheB1LSKHd5d04pr4Tg==",
 			"dev": true,
 			"requires": {
 				"@lerna/npm-conf": "^3.0.0",
@@ -1484,9 +1472,9 @@
 			}
 		},
 		"@lerna/symlink-binary": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.0.0.tgz",
-			"integrity": "sha512-ElV1ij0ZiOw5j1bZqg9K+q+dV/DJVvMZxP+oj3vsP4SgnG3EdWxBIbE7TCZHbLZtF0LNJsrquGCkdqk17svx/w==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.1.4.tgz",
+			"integrity": "sha512-uQ8pYxzygahshXJAeC/vY4eSi+kFM0S2Pi15hJsJI3W7Ec6ysSYU1lXemb6kqoIqkTDJZWnfKXEq/3FLE+JYhg==",
 			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "^3.0.0",
@@ -1548,14 +1536,14 @@
 			}
 		},
 		"@lerna/symlink-dependencies": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.0.0.tgz",
-			"integrity": "sha512-INPlVkuGbneQ2gKf/pe3FlvcSXOk+KbZShQsrcvvYhIjK/td1g6ToMGLhml7lNmQxL90YiAqo23Q8nwIh0HAIA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.1.4.tgz",
+			"integrity": "sha512-iModwb0Xh0N0t55C6S4K2mzLdu1zXVsBc0qubUY1x0RSul92z8NeAe1aM5JzwMzuSoMA/LRiD1lNMWMRBf4JVg==",
 			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "^3.0.0",
 				"@lerna/resolve-symlink": "^3.0.0",
-				"@lerna/symlink-binary": "^3.0.0",
+				"@lerna/symlink-binary": "^3.1.4",
 				"fs-extra": "^6.0.1",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
@@ -1585,25 +1573,27 @@
 			}
 		},
 		"@lerna/version": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.1.0.tgz",
-			"integrity": "sha512-TRMWskJNUUxKSlLaW9dTpuGtoFVddLYXAt32tWcj7e6pSnRv8Tc3eevc77I4i4FkcxTMm+54iA4AJoGp6c1fgQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.2.0.tgz",
+			"integrity": "sha512-1AVDMpeecSMiG1cacduE+f2KO0mC7F/9MvWsHtp+rjkpficMcsVme7IMtycuvu/F07wY4Xr9ioFKYTwTcybbIA==",
 			"dev": true,
 			"requires": {
+				"@lerna/batch-packages": "^3.1.2",
 				"@lerna/check-working-tree": "^3.1.0",
 				"@lerna/child-process": "^3.0.0",
 				"@lerna/collect-updates": "^3.1.0",
-				"@lerna/command": "^3.1.0",
+				"@lerna/command": "^3.1.3",
 				"@lerna/conventional-commits": "^3.0.2",
 				"@lerna/output": "^3.0.0",
 				"@lerna/prompt": "^3.0.0",
-				"@lerna/run-lifecycle": "^3.0.0",
+				"@lerna/run-lifecycle": "^3.2.0",
 				"@lerna/validation-error": "^3.0.0",
 				"chalk": "^2.3.1",
 				"dedent": "^0.7.0",
 				"minimatch": "^3.0.4",
 				"npmlog": "^4.1.2",
 				"p-map": "^1.2.0",
+				"p-pipe": "^1.2.0",
 				"p-reduce": "^1.0.0",
 				"p-waterfall": "^1.0.0",
 				"semver": "^5.5.0",
@@ -1638,9 +1628,9 @@
 			"dev": true
 		},
 		"@nodelib/fs.stat": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
-			"integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz",
+			"integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA==",
 			"dev": true
 		},
 		"@speedy/commit-msg-hook": {
@@ -1791,7 +1781,6 @@
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2",
 				"longest": "^1.0.1",
@@ -4134,7 +4123,7 @@
 		},
 		"external-editor": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
@@ -4543,9 +4532,9 @@
 			}
 		},
 		"figgy-pudding": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.1.tgz",
-			"integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
 		},
 		"figures": {
@@ -4779,8 +4768,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4801,14 +4789,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4823,20 +4809,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4953,8 +4936,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4966,7 +4948,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4981,7 +4962,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4989,14 +4969,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5015,7 +4993,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5096,8 +5073,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5109,7 +5085,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5195,8 +5170,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5232,7 +5206,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5252,7 +5225,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5296,14 +5268,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -6131,9 +6101,9 @@
 			},
 			"dependencies": {
 				"rxjs": {
-					"version": "5.5.11",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-					"integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+					"version": "5.5.12",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
 					"dev": true,
 					"requires": {
 						"symbol-observable": "1.0.1"
@@ -7324,12 +7294,26 @@
 			"dev": true
 		},
 		"lerna": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.1.1.tgz",
-			"integrity": "sha512-uoOfVSGv6i9OT1KG7nZPviRiFlKPy4pUnqVXZxrwcY3u2h5UsxQRW9A5vAMHXW8r/4p/OaxnOqUptB3j5ychNw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.2.1.tgz",
+			"integrity": "sha512-nHa/TgRLOHlBm+NfeW62ffVO7hY7wJxnu6IJmZA3lrSmRlqrXZk2BPvnq0FSaCinVYjW0w0XeSNZdRKR//HAwQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/cli": "^3.1.1",
+				"@lerna/add": "^3.2.0",
+				"@lerna/bootstrap": "^3.2.0",
+				"@lerna/changed": "^3.2.0",
+				"@lerna/clean": "^3.1.3",
+				"@lerna/cli": "^3.2.0",
+				"@lerna/create": "^3.1.3",
+				"@lerna/diff": "^3.1.3",
+				"@lerna/exec": "^3.1.3",
+				"@lerna/import": "^3.1.3",
+				"@lerna/init": "^3.1.3",
+				"@lerna/link": "^3.1.4",
+				"@lerna/list": "^3.1.3",
+				"@lerna/publish": "^3.2.1",
+				"@lerna/run": "^3.1.3",
+				"@lerna/version": "^3.2.0",
 				"import-local": "^1.0.0",
 				"npmlog": "^4.1.2"
 			}
@@ -7503,8 +7487,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
 			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -8974,13 +8957,14 @@
 			}
 		},
 		"npm-registry-fetch": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.2.1.tgz",
-			"integrity": "sha512-td1r58BhyzoQsOlsbhLQf9M9t4TlypgsQ4vdf0lauci/rIAlmCyXAAEwh5ZyEy5TYLwxDYpX2CMa8ON9j3VJLA==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.8.0.tgz",
+			"integrity": "sha512-hrw8UMD+Nob3Kl3h8Z/YjmKamb1gf7D1ZZch2otrIXM3uFLB5vjEY6DhMlq80z/zZet6eETLbOXcuQudCB3Zpw==",
 			"dev": true,
 			"requires": {
+				"JSONStream": "^1.3.4",
 				"bluebird": "^3.5.1",
-				"figgy-pudding": "^3.2.0",
+				"figgy-pudding": "^3.4.1",
 				"lru-cache": "^4.1.3",
 				"make-fetch-happen": "^4.0.1",
 				"npm-package-arg": "^6.1.0"
@@ -9291,6 +9275,12 @@
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
+		},
+		"p-pipe": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+			"dev": true
 		},
 		"p-reduce": {
 			"version": "1.0.0",
@@ -11283,10 +11273,13 @@
 			}
 		},
 		"ssri": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
-			"integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA==",
-			"dev": true
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"dev": true,
+			"requires": {
+				"figgy-pudding": "^3.5.1"
+			}
 		},
 		"stack-utils": {
 			"version": "1.0.1",
@@ -11452,7 +11445,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
 					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
 					"dev": true
 				}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"jest": "^23.0.0",
 		"jest-localstorage-mock": "^2.1.0",
 		"jest-preset-angular": "^6.0.0",
-		"lerna": "3.1.1",
+		"lerna": "3.2.1",
 		"lodash": "^4.17.4",
 		"ng-packagr": "^4.0.0",
 		"rimraf": "^2.6.2",

--- a/tools/tasks/release.ts
+++ b/tools/tasks/release.ts
@@ -60,4 +60,8 @@ const modulePath = resolve("./node_modules/@lerna/npm-publish/npm-publish.js");
 
 require("module")._cache[modulePath].exports = lernaNpmPublish;
 process.argv.splice(0, 2, "publish");
-require("@lerna/cli")().parse(process.argv);
+
+const publishCmd = require("@lerna/publish/command");
+require("@lerna/cli")()
+	.command(publishCmd)
+	.parse(process.argv);

--- a/tools/tasks/release.ts
+++ b/tools/tasks/release.ts
@@ -3,6 +3,7 @@ import * as lernaNpmPublish from "@lerna/npm-publish";
 import { join, resolve } from "path";
 import { execSync } from "child_process";
 import { readJsonSync, writeJsonSync } from "fs-extra";
+const log = require('npmlog');
 
 interface PackageJson {
 	name?: string;
@@ -41,24 +42,55 @@ try {
 	process.exit(1);
 }
 
+// Lerna's maintainers have refused to allow publishing from a subdirectory,
+// so we are going to monkey-patch the helper library that does this
+//
 // https://github.com/lerna/lerna/issues/91
-const originalNpmPublish = (lernaNpmPublish as any).npmPublish;
-(lernaNpmPublish as any).publishTaggedInDir = (
-	pkg: any,
-	tag: string,
-	{ npmClient, registry }: { npmClient: string, registry: string }
-) => {
-	updateDistPackageJson(pkg.location);
-	const amendedPkg = {
-		...pkg,
-		location: join(pkg.location, "dist")
-	};
-	originalNpmPublish(amendedPkg, tag, { npmClient, registry });
+
+type Pkg = PackageJson & { location: string, rootPath: string; tarball: any };
+
+const originalNpmPack = (lernaNpmPublish as any).npmPack;
+
+const npmPack = (rootManifest: any, packages: Pkg[]) => {
+	// modify the packages array in place
+	// because pkg.location is readonly so we can't modify each pkg
+	// and the packages array needs to be shared between the two calls into the npm-publish helper library:
+	// - first, npmPack, which attaches pkg.tarball = $(npm pack --json pkg.location) to each
+	// - second, npmPublish, which reads the same (===) array and expects to find pkg.tarball.filename,
+	//	 and runs `npm publish ${pkg.tarball.filename}`
+	// it is a little bad that the lib depends on array mutations happening between otherwise unrelated calls, but what can you do
+	for (let i = 0; i < packages.length; i++) {
+		let pkg = packages[i];
+		updateDistPackageJson(pkg.location);
+		const joined = join(pkg.location, "dist");
+		// you could use log output to make a test suite for the monkey-patching
+		log.info('intercepted @lerna/npm-publish ', 'publishing', pkg.name, 'from', joined, 'instead');
+		packages[i] = {
+			...pkg,
+			location: joined,
+			// and also there is some weirdness with ...pkg not including all properties
+			// this solves it for whatever reason
+			rootPath: pkg.rootPath,
+			version: pkg.version,
+		};
+	}
+	return originalNpmPack(rootManifest, packages /* opts -> gets default value */);
 };
 
+// somewhat reimplement https://github.com/lerna/lerna/blob/master/utils/npm-publish/npm-publish.js
 const modulePath = resolve("./node_modules/@lerna/npm-publish/npm-publish.js");
+// just monkey-patching npmPack is not enough or even useful -- that API is not used directly,
+// it is only used through makePacker
+require("module")._cache[modulePath].exports.npmPack = npmPack;
+require("module")._cache[modulePath].exports.makePacker = (rootManifest: any) => {
+	// original redundantly specifies opts here
+	// passing no opts will cause originalNpmPack to create opts = makePackOptions(rootManifest)
+	// which is what we want
+	return (packages: Pkg[]) => npmPack(rootManifest, packages);
+};
 
-require("module")._cache[modulePath].exports = lernaNpmPublish;
+// strip '/path/to/node/binary'  and  './tools/tasks/release.js'
+// replace with 'publish'
 process.argv.splice(0, 2, "publish");
 
 const publishCmd = require("@lerna/publish/command");


### PR DESCRIPTION
Lerna changed the way the CLI pulls together the various command modules/yargs commands.

https://github.com/lerna/lerna/commit/7200fd0

So now you have to ask `@lerna/cli` to load the publish subcommand before attempting to parse, otherwise it fails with `unknown argument preid`, etc.

Don't merge yet. It occurs to me there are more changes to npmPublish under the hood and it still doesn't work.